### PR TITLE
Fix negative timezone bug introduced when migrating to python 3

### DIFF
--- a/offlineimap/imaplibutil.py
+++ b/offlineimap/imaplibutil.py
@@ -271,7 +271,7 @@ def Internaldate2epoch(resp):
     # INTERNALDATE timezone must be subtracted to get UT
 
     zone = (zoneh * 60 + zonem) * 60
-    if zonen == '-':
+    if zonen == b'-':
         zone = -zone
 
     tt = (year, mon, day, hour, minu, sec, -1, -1, -1)


### PR DESCRIPTION
The timezone's negative sign must be checked against a byte-string, rather than the python 3 unicode string. Way back in 2011 this bug was fixed in what is likely the original sourcecode for Internaldate2epoch(), see: https://github.com/python/cpython/issues/55148

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [ x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [ x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [ x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x ] Code changes follow the style of the files they change.
- [ x] Code is tested (provide details).

### References

- Issue #no_space

### Additional information


